### PR TITLE
Fix NullReferenceException in RefreshZoom

### DIFF
--- a/ABStudio/Forms/SpritesheetEditor.cs
+++ b/ABStudio/Forms/SpritesheetEditor.cs
@@ -69,6 +69,8 @@ namespace ABStudio.Forms
 
         public SpritesheetEditor(string path, DATFile file)
         {
+            spritesheet = new Bitmap(1, 1);
+
             InitializeComponent();
 
             originalPath = path;

--- a/ABStudio/Forms/SpritesheetEditor.cs
+++ b/ABStudio/Forms/SpritesheetEditor.cs
@@ -69,8 +69,6 @@ namespace ABStudio.Forms
 
         public SpritesheetEditor(string path, DATFile file)
         {
-            spritesheet = new Bitmap(1, 1);
-
             InitializeComponent();
 
             originalPath = path;
@@ -499,6 +497,14 @@ namespace ABStudio.Forms
 
         private void RefreshZoom()
         {
+            if (spritesheet == null)
+            {
+                // On some computers, this method may be called by `InitializeComponent` in the class constructor.
+                // In this case, `spritesheet` is null, which can cause NullReferenceException to be thrown.
+                
+                spritesheet = new Bitmap(1, 1);
+            }
+            
             float w = spritesheet.Width * zoom;
             float h = spritesheet.Height * zoom;
 


### PR DESCRIPTION
On some devices ABStudio will throw NullReferenceException (`spritesheet` is null) when open the spritesheet editor